### PR TITLE
Azure Blob Storage Python Destination - Resolved object/dict serialization

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage-python/Dockerfile
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage-python/Dockerfile
@@ -1,10 +1,12 @@
-FROM airbyte/python-connector-base:1.1.0 AS base
+FROM airbyte/python-connector-base:2.0.0 AS base
 
-COPY . ./airbyte/integration_code
+COPY pyproject.toml ./airbyte/integration_code/pyproject.toml
 WORKDIR /airbyte/integration_code
 RUN pip install poetry
-RUN poetry install --no-cache -C ./airbyte/integration_code
+RUN poetry install --no-root --no-cache -C ./airbyte/integration_code
 
+COPY . ./airbyte/integration_code
+RUN poetry install --only-root --no-cache -C ./airbyte/integration_code
 
 ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/destination-azure-blob-storage-python/Dockerfile
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage-python/Dockerfile
@@ -1,12 +1,10 @@
 FROM airbyte/python-connector-base:2.0.0 AS base
 
-COPY pyproject.toml ./airbyte/integration_code/pyproject.toml
+COPY . ./airbyte/integration_code
 WORKDIR /airbyte/integration_code
 RUN pip install poetry
-RUN poetry install --no-root --no-cache -C ./airbyte/integration_code
+RUN poetry install --no-cache -C ./airbyte/integration_code
 
-COPY . ./airbyte/integration_code
-RUN poetry install --only-root --no-cache -C ./airbyte/integration_code
 
 ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/destination-azure-blob-storage-python/destination_azure_blob_storage_python/stream_writer.py
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage-python/destination_azure_blob_storage_python/stream_writer.py
@@ -96,7 +96,7 @@ class StreamWriter:
                 for key, val in value.items():
                     if key in props:
                         value[key] = self._json_schema_cast_value(val, props[key])
-                return value
+                return json.dumps(value, default=str)
 
         elif typ == "array" and items:
             if value in EMPTY_VALUES:

--- a/airbyte-integrations/connectors/destination-azure-blob-storage-python/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage-python/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 9384da68-c49b-46af-83fd-b73b45442fff
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: us-central1-docker.pkg.dev/airbyte-custom-connectors/ovative/airbyte-destination-azure-blob-storage-python-dev
   githubIssueLabel: destination-azure-blob-storage-python
   icon: icon.svg

--- a/airbyte-integrations/connectors/destination-azure-blob-storage-python/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage-python/pyproject.toml
@@ -3,10 +3,10 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.4"
+version = "0.3.5"
 name = "destination-azure-blob-storage-python"
 description = "Destination implementation for azure-blob-storage-python."
-authors = [ "Airbyte <contact@airbyte.io>",]
+authors = [ "Tim Mock <tim.mock@ovative.com>", "Woodrow Keifenheim <woodrow.keifenheim@ovative.com"]
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.airbyte.com/integrations/destinations/azure-blob-storage-python"


### PR DESCRIPTION
## What
Pyarrow does not automatically map a Python dict to a struct (or dictionary).. we would have to statically parse those structures and define their schemas. Much easier (and safer) to cast the whole thing to a JSON string.

[EMRGE-2009](https://ovative.atlassian.net/browse/EMRGE-2009)

## How
Record columns were already being type casted, however the object columns were remaining a {key: value} pairs within the record-column. Converting that whole record-column to JSON resolves the need to go down a nested schema rabbit whole.

I updated the base image of the docker build but otherwise stopped short of trying to minimize the total image size, will create a specific backlog ticket to try and do that stuff. Similar with updating base image utils, and reordering build steps to better make use of layer caching.

We may need to consider enabling flattening for parquet and avro formats too.. The TikTok steams Atlas are interested in contains most of their data within object types (metrics and dimensions), unpacking those columns will have to happen somewhere so if we encounter more steams like TikTok then it would be worth enabling flattening for parquet and avro too.

I did a manual regression test on Facebook data to ensure the recursive call of _json_schema_cast_value did not lead to schema changes, and it does not appear that it did. We need integration tests to cover these.. will look at next sprint or the following to start writing tests.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Can now sync data from TikTok.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
